### PR TITLE
Enable fenced code blocks in text summaries

### DIFF
--- a/tensorboard/plugin_util.py
+++ b/tensorboard/plugin_util.py
@@ -65,7 +65,8 @@ _ALLOWED_TAGS = [
 class _MarkdownStore(threading.local):
     def __init__(self):
         self.markdown = markdown.Markdown(
-            extensions=["markdown.extensions.tables"]
+            extensions=["markdown.extensions.tables",
+                        "markdown.extensions.fenced_code"]
         )
 
 


### PR DESCRIPTION
* Motivation for features / changes

My particular use case is dumping a json config file, but the fenced code syntax is pretty common in markdown and I suspect it will have lots of uses.

https://www.markdownguide.org/extended-syntax/#fenced-code-blocks

* Technical description of changes

Just adds the `fenced_code` extension.

* Screenshots of UI changes

![image](https://user-images.githubusercontent.com/23426/105259918-9eca6c00-5b41-11eb-95a4-2192302f5b08.png)

* Detailed steps to verify changes work correctly (as executed by you)

Log a text event with a fenced code block, verify it renders correctly.

* Alternate designs / implementations considered

I don't know another good way to include a block of preformatted text.